### PR TITLE
inital attempt to fix spinaker permissions stuff

### DIFF
--- a/devices/dev/default.nix
+++ b/devices/dev/default.nix
@@ -24,10 +24,10 @@
   };
   
   # spinaker/flir udev rules
-  services.udev.extraRules = "
-  SUBSYSTEM==\"usb\", ATTRS{idVendor}==\"1e10\", GROUP=\"flirimaging\"
-  SUBSYSTEM==\"usb\", ATTRS{idVendor}==\"1724\", GROUP=\"flirimaging\"
-";
+  services.udev.extraRules = ''
+    SUBSYSTEM=="usb", ATTRS{idVendor}=="1e10", GROUP="flirimaging"
+    SUBSYSTEM=="usb", ATTRS{idVendor}=="1724", GROUP="flirimaging"
+  '';
 
   # spinaker usbfs requirments
   boot.kernelParams = [ "usbcore.usbfs_memory_mb=1000" ];

--- a/devices/dev/default.nix
+++ b/devices/dev/default.nix
@@ -18,10 +18,19 @@
         isNormalUser = true;
         createHome = true; # Automatically create a home directory for the user
         home = "/home/toliman";
-        extraGroups = [ "wheel" "networkmanager" "docker" ];
+        extraGroups = [ "wheel" "networkmanager" "docker" "flirimaging" ];
       };
     };
   };
+  
+  # spinaker/flir udev rules
+  services.udev.extraRules = "
+  SUBSYSTEM==\"usb\", ATTRS{idVendor}==\"1e10\", GROUP=\"flirimaging\"
+  SUBSYSTEM==\"usb\", ATTRS{idVendor}==\"1724\", GROUP=\"flirimaging\"
+";
+
+  # spinaker usbfs requirments
+  boot.kernelParams = [ "usbcore.usbfs_memory_mb=1000" ];
 
   # Dev software
   environment.systemPackages = with pkgs; [


### PR DESCRIPTION
attempt to add the needed dev rules and users memory tweaks for spinnaker to work.

I think we need to add a couple things to config to make the spinaker stuff work (these were done by normal install on the other Jetson tester)
manually done via `sudo sh -c 'echo 1000 > /sys/module/usbcore/parameters/usbfs_memory_mb'`

I think this is nix way:
```
boot.kernelParams = [ "usbcore.usbfs_memory_mb=1000" ];
```

the other issue is the missing udev rules, to allow non sudo user to access the device, there is normally a group called **_flirimaging_**, and this is done in configuration script
```
# Create udev rule
UdevFile="/etc/udev/rules.d/40-flir-spinnaker.rules"
echo
echo "Writing the udev rules file...";
echo "SUBSYSTEM==\"usb\", ATTRS{idVendor}==\"1e10\", GROUP=\"$grpname\"" 1>>$UdevFile
echo "SUBSYSTEM==\"usb\", ATTRS{idVendor}==\"1724\", GROUP=\"$grpname\"" 1>>$UdevFile
```

I think this is nix way:

  services.udev.extraRules = "
  SUBSYSTEM==\"usb\", ATTRS{idVendor}==\"1e10\", GROUP=\"flirimaging\"
  SUBSYSTEM==\"usb\", ATTRS{idVendor}==\"1724\", GROUP=\"flirimaging\"
";

```